### PR TITLE
UNIX style stdin/stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Data Format
 
 Usage
 -----
-    usage: __main__.py [-h] [-c CONFIG_DIR] [-k [KEY_NAMES [KEY_NAMES ...]]]
-                       [--all-keys] [-d DATE] [-v] [-V] [--sample-config]
-                       [--skip-send] [--save-sheet-to SAVE_SHEET_TO] [--stdin]
-                       [--stdout-markdown] [--stdout-email]
-                       [--active | --dryrun | --test]
+    usage: email [-h] [-c CONFIG_DIR] [-k [KEY_NAMES [KEY_NAMES ...]]]
+                 [--all-keys] [-d DATE] [-v] [-V] [--sample-config] [--skip-send]
+                 [--save-sheet-to SAVE_SHEET_TO] [--stdin] [--stdout-markdown]
+                 [--stdout-email] [--active | --dryrun | --test]
     
     optional arguments:
       -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Data Format
 
 Usage
 -----
-    usage: email [-h] [-c CONFIG_DIR] [-k [KEY_NAMES [KEY_NAMES ...]]]
-                 [--all-keys] [-d DATE] [-v] [-V] [--sample-config] [--active]
-                 [--dryrun] [--test]
-
+    usage: __main__.py [-h] [-c CONFIG_DIR] [-k [KEY_NAMES [KEY_NAMES ...]]]
+                       [--all-keys] [-d DATE] [-v] [-V] [--sample-config]
+                       [--skip-send] [--save-sheet-to SAVE_SHEET_TO] [--stdin]
+                       [--stdout-markdown] [--stdout-email]
+                       [--active | --dryrun | --test]
+    
     optional arguments:
       -h, --help            show this help message and exit
       -c CONFIG_DIR, --config-dir CONFIG_DIR
@@ -31,12 +33,56 @@ Usage
       -d DATE, --date DATE  Date for which to send emails (YYYY-MM-DD). The
                             default is today.
       -v, --verbose         Display more logging output
-      -V, --version         Print the current emailer module version.
+      -V, --version         Print the current emailer module version and exit.
       --sample-config       Print a sample config. Save as emailer.json or
-                            .emailer.json.
+                            .emailer.json and exit.
+      --skip-send           Avoid actually sending emails, useful for testing.
+      --save-sheet-to SAVE_SHEET_TO
+                            Save the sheet into the following JSON file.
+      --stdin               Use STDIN to get the sheet data, instead of directly
+                            from Google Sheets.
+      --stdout-markdown     Print a JSON array of unhighlighted email,still in
+                            markdown.
+      --stdout-email        Print a JSON array all highlighted email messages.
       --active              Send emails to all active recipients.
       --dryrun              Send emails one day early to dryrun recipients.
       --test                Send emails only to test recipients.
+      
+### Examples
+
+Send a message for today's date to all Active recipients on the list `mykey`:
+```bash
+python -m emailer -k mykey --active
+```
+
+See what would happen if today's email went out, but don't actually send email:
+```bash
+python -m emailer -k mkey --active --verbose --skip-send
+```
+
+Send a dryrun version of tomorrow's email to DryRun recipients:
+```bash
+python -m emailer -k mykey --dryrun
+```
+
+Send a dryrun version of a specific date to the DryRun recipients.
+```bash
+python -m emailer -k mykey --dryrun -d 2019-10-20
+```
+
+Provide a cached json sheet, and return a list of email (doesn't send or lookup anything on the server):
+```bash
+cat sheet.json | python -m emailer -k mkey --active --skip-send --stdin --stdout-email
+[
+    "Subject: Schedule for 2019-10-26\nFrom: Schedule Emailer <me@example.com>\nTo: alice@example.com\nReply-To: Robert Wallis <robert@example.com>\nContent-Type: text/html; charset=\"utf-8\"\nContent-Transfer-Encoding: quoted-printable\nMIME-Version: 1.0\n\n<p>=No Meeting Today</p>\n",
+    "Subject: Schedule for 2019-10-26\nFrom: Schedule Emailer <me@example.com>\nTo: bob@example.com\nReply-To: Robert Wallis <robert@example.com>\nContent-Type: text/html; charset=\"utf-8\"\nContent-Transfer-Encoding: quoted-printable\nMIME-Version: 1.0\n\n<p>=No Meeting Today</p>\n",
+]    
+```
+
+Get the sheet from Google Sheets and cache it.
+```bash
+python -m emailer -k mykey --test --skip-send --save-sheet-to sheet.json
+```
 
 Setup
 -----

--- a/emailer/__main__.py
+++ b/emailer/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from . import shell
 from .args import get_parsed_args, get_sample_config, get_version
@@ -10,17 +11,16 @@ def main():
   setup_logging(options.log_level)
   if options.version:
     print(get_version())
-  elif options.sample_config:
+    return 0
+  if options.sample_config:
     print(get_sample_config())
-  elif options.group:
-    shell.process_sheets(group=options.group,
-                         config_dir=options.config_dir,
-                         key_names=options.key_names,
-                         all_keys=options.all_keys,
-                         date=options.send_date,
-                         skip=options.skip_send)
-  else:
+    return 0
+
+  if not options.group:
     print('No group provided')
+    return -1
+
+  return shell.process(options)
 
 
 def setup_logging(level):
@@ -28,5 +28,10 @@ def setup_logging(level):
                       format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
 
 
-if __name__ == '__main__':
-  main()
+def init():
+  """allow 100% coverage by putting the __name__ check in a function"""
+  if __name__ == '__main__':
+    exit_code = main()
+    sys.exit(exit_code)
+
+init()

--- a/emailer/args.py
+++ b/emailer/args.py
@@ -35,6 +35,16 @@ def get_parser():
                            '.emailer.json and exit.')
   parser.add_argument('--skip-send', action='store_true',
                       help='Avoid actually sending emails, useful for testing.')
+  parser.add_argument('--save-sheet-to',
+                      help='Save the sheet into the following JSON file.')
+  parser.add_argument('--stdin', action='store_true',
+                      help='Use STDIN to get the sheet data, instead of '
+                           'directly from Google Sheets.')
+  parser.add_argument('--stdout-markdown', action='store_true',
+                      help='Print a JSON array of unhighlighted email,'
+                           'still in markdown.')
+  parser.add_argument('--stdout-email', action='store_true',
+                      help='Print a JSON array all highlighted email messages.')
   # Only one group can be specified per-run.
   group = parser.add_mutually_exclusive_group()
   group.add_argument('--active', action='store_true',

--- a/emailer/send.py
+++ b/emailer/send.py
@@ -2,15 +2,13 @@ import logging
 import time
 
 
-def send_messages(messages, sender, skip, sleep=1):
+def send_messages(messages, sender, sleep=1):
   for message in messages:
-    send_message(message=message, sender=sender, skip=skip)
+    send_message(message=message, sender=sender)
     if sleep:
       time.sleep(sleep) # Avoids 500: Backend Error.
 
 
-def send_message(*, message, sender, skip=False):
-  if skip:
-    return None
+def send_message(*, message, sender):
   logging.info(message)
   return sender.send(message)

--- a/emailer/shell.py
+++ b/emailer/shell.py
@@ -127,13 +127,12 @@ def compose_input_google_sheets(options: Options, config: Config, creds):
   Returns a function `()->Generator(sheet)` to get spreadsheets from Google.
   """
 
-  def _get_google_sheets():
-    nonlocal creds, options, config
+  def get_google_sheets():
     sheet_ids = google_sheet_ids(options, config)
     for sheet_id in sheet_ids:
       yield fetcher.values(sheet_id, api.sheets(creds))
 
-  return _get_google_sheets
+  return get_google_sheets
 
 
 def input_sheet_from_stdin():
@@ -153,11 +152,10 @@ def compose_output_gmail_sender(creds):
   """Returns a function (messages)->Null to send each message via Gmail."""
   sender = GmailSender(api.gmail(creds))
 
-  def _output_gmail_sender(messages):
-    nonlocal sender
+  def output_gmail_sender(messages):
     send_messages(messages, sender)
 
-  return _output_gmail_sender
+  return output_gmail_sender
 
 
 def output_stdout_email(messages):

--- a/emailer/shell.py
+++ b/emailer/shell.py
@@ -86,11 +86,10 @@ def output_sheet(options: Options,
   send the sheet to the output functions
   """
   extra_values = config.get_extra_values()
-  markdowns = markdown_emails_for_date(sheet=sheet,
-                                       send_date=options.send_date,
-                                       group=options.group,
-                                       extra_values=extra_values)
-  markdowns = list(markdowns)  # take out generator for multiple sends
+  markdowns = list(markdown_emails_for_date(sheet=sheet,
+                                            send_date=options.send_date,
+                                            group=options.group,
+                                            extra_values=extra_values))
   for send_output in markdown_outputs:
     send_output(markdowns)
 
@@ -99,11 +98,10 @@ def output_sheet(options: Options,
     return
 
   extra_recipients = config.get_extra_recipients_for_group(options.group)
-  messages = messages_from_markdown(sheet,
-                                    markdowns,
-                                    options.group,
-                                    extra_recipients)
-  messages = list(messages)  # take out of generator for multiple sends
+  messages = list(messages_from_markdown(sheet,
+                                         markdowns,
+                                         options.group,
+                                         extra_recipients))
 
   for send_output in message_outputs:
     send_output(messages)

--- a/emailer/shell.py
+++ b/emailer/shell.py
@@ -33,9 +33,7 @@ def process(options: Options):
 
 
 def decide_input_source(options: Options, config: Config, creds):
-  """
-  :return: a function that returns sheets
-  """
+  """:return: a function that returns sheets"""
   if options.stdin:
     return input_sheet_from_stdin
   return compose_input_google_sheets(options=options,
@@ -44,9 +42,7 @@ def decide_input_source(options: Options, config: Config, creds):
 
 
 def decide_markdown_outputs(options: Options):
-  """
-  :return: a list of functions that output markdown
-  """
+  """:return: a list of functions that output markdown"""
   markdown_senders = []
   if options.stdout_markdown:
     markdown_senders.append(output_stdout_markdown)
@@ -54,9 +50,7 @@ def decide_markdown_outputs(options: Options):
 
 
 def decide_message_outputs(options: Options, creds):
-  """
-  :return: a list of functions that output email messages
-  """
+  """:return: a list of functions that output email messages"""
   message_senders = []
   if options.stdout_email:
     message_senders.append(output_stdout_email)
@@ -82,9 +76,7 @@ def output_sheet(options: Options,
                  markdown_outputs: list,
                  message_outputs: list,
                  sheet):
-  """
-  send the sheet to the output functions
-  """
+  """send the sheet to the output functions"""
   extra_values = config.get_extra_values()
   markdowns = list(markdown_emails_for_date(sheet=sheet,
                                             send_date=options.send_date,

--- a/emailer/shell.py
+++ b/emailer/shell.py
@@ -72,10 +72,9 @@ def save_sheet(save_sheet_to: str, sheet):
    as JSON
   :param sheet: data to be dumped into the file
   """
-  if save_sheet_to is None or len(save_sheet_to) == 0:
-    return
-  with open(save_sheet_to, 'w+') as stream:
-    json.dump(sheet, stream, indent=4)
+  if save_sheet_to:
+    with open(save_sheet_to, 'w+') as stream:
+      json.dump(sheet, stream, indent=4)
 
 
 def output_sheet(options: Options,

--- a/emailer/shell.py
+++ b/emailer/shell.py
@@ -1,48 +1,211 @@
+import json
 import logging
+import sys
 
-from . import api, auth, composer, config, fetcher, parser
+from . import api, auth, composer, fetcher, parser, config as config_module
+from .config import Config
 from .gmailsender import GmailSender
 from .messagebuilder import create_message_for_recipient
-from .send import send_messages
 from .name import SUBJECT, BODY, EMAILS, RECIPIENTS, PREFIX
+from .options import Options
+from .send import send_messages
 
 
-def get_messages(data, date, group, extra_recipients, extra_values):
-  emails = parser.parse_emails_for_date(data.get(EMAILS), date)
-  recipients = parser.parse_recipients_in_group(data.get(RECIPIENTS), group)
-  all_recipients = [*recipients, *extra_recipients]
+def process(options: Options):
+  """Gather input data, format it, and send out email."""
+  config = load_config(options.config_dir)
+  config, creds = validate_creds(options, config)
+
+  input_source = decide_input_source(options=options,
+                                     config=config,
+                                     creds=creds)
+  markdown_outputs = decide_markdown_outputs(options=options)
+  message_outputs = decide_message_outputs(options=options, creds=creds)
+
+  for sheet in input_source():
+    save_sheet(save_sheet_to=options.save_sheet_to, sheet=sheet)
+    output_sheet(options=options,
+                 config=config,
+                 markdown_outputs=markdown_outputs,
+                 message_outputs=message_outputs,
+                 sheet=sheet)
+  return 0
+
+
+def decide_input_source(options: Options, config: Config, creds):
+  """
+  :return: a function that returns sheets
+  """
+  if options.stdin:
+    return input_sheet_from_stdin
+  return compose_input_google_sheets(options=options,
+                                     config=config,
+                                     creds=creds)
+
+
+def decide_markdown_outputs(options: Options):
+  """
+  :return: a list of functions that output markdown
+  """
+  markdown_senders = []
+  if options.stdout_markdown:
+    markdown_senders.append(output_stdout_markdown)
+  return markdown_senders
+
+
+def decide_message_outputs(options: Options, creds):
+  """
+  :return: a list of functions that output email messages
+  """
+  message_senders = []
+  if options.stdout_email:
+    message_senders.append(output_stdout_email)
+  if not options.skip_send:
+    message_senders.append(compose_output_gmail_sender(creds))
+  return message_senders
+
+
+def save_sheet(save_sheet_to: str, sheet):
+  """
+  If the filename is set, then it will save the sheet to the location.
+  :param save_sheet_to: filename location where the sheet will be dumped
+   as JSON
+  :param sheet: data to be dumped into the file
+  """
+  if save_sheet_to is None or len(save_sheet_to) == 0:
+    return
+  with open(save_sheet_to, 'w+') as stream:
+    json.dump(sheet, stream, indent=4)
+
+
+def output_sheet(options: Options,
+                 config: Config,
+                 markdown_outputs: list,
+                 message_outputs: list,
+                 sheet):
+  """
+  send the sheet to the output functions
+  """
+  extra_values = config.get_extra_values()
+  markdowns = markdown_emails_for_date(sheet=sheet,
+                                       send_date=options.send_date,
+                                       group=options.group,
+                                       extra_values=extra_values)
+  markdowns = list(markdowns)  # take out generator for multiple sends
+  for send_output in markdown_outputs:
+    send_output(markdowns)
+
+  if len(message_outputs) == 0:
+    # won't send any messages so don't need to generate them
+    return
+
+  extra_recipients = config.get_extra_recipients_for_group(options.group)
+  messages = messages_from_markdown(sheet,
+                                    markdowns,
+                                    options.group,
+                                    extra_recipients)
+  messages = list(messages)  # take out of generator for multiple sends
+
+  for send_output in message_outputs:
+    send_output(messages)
+
+
+def markdown_emails_for_date(sheet, send_date, group, extra_values):
+  """Yields composed markdown emails for the given date."""
+  emails = parser.parse_emails_for_date(sheet.get(EMAILS), send_date)
   prefix = composer.get_prefix_for_group(group)
   for email in emails:
     values = composer.replace_values({PREFIX: prefix, **email, **extra_values})
-    subject = prefix + composer.substitute_for_key(SUBJECT, values)
     body = composer.substitute_for_key(BODY, values)
+    subject = prefix + composer.substitute_for_key(SUBJECT, values)
+    logging.info(subject)
     logging.info(body)
+    yield (subject, body, values)
+
+
+def messages_from_markdown(sheet, markdowns, group, extra_recipients):
+  """Yields messages formatted for each recipient."""
+  recipients = parser.parse_recipients_in_group(sheet.get(RECIPIENTS), group)
+  all_recipients = [*recipients, *extra_recipients]
+  for (subject, body, values) in markdowns:
     for recipient in all_recipients:
       if recipient.is_valid():
         yield create_message_for_recipient(recipient, subject, body, values)
 
 
-def get_config(config_dir):
-  config_path = config.find_config_file(config_dir)
-  config_obj = config.load_from_file(config_path)
-  config_obj.validate()
+def compose_input_google_sheets(options: Options, config: Config, creds):
+  """
+  Returns a function `()->Generator(sheet)` to get spreadsheets from Google.
+  """
+
+  def _get_google_sheets():
+    nonlocal creds, options, config
+    sheet_ids = google_sheet_ids(options, config)
+    for sheet_id in sheet_ids:
+      yield fetcher.values(sheet_id, api.sheets(creds))
+
+  return _get_google_sheets
+
+
+def input_sheet_from_stdin():
+  """Yields the full contents of a sheet supplied via stdin piping."""
+  data = sys.stdin.read()
+  yield json.loads(data)
+
+
+def output_stdout_markdown(markdowns):
+  """Prints the markdown version of the email to the console in JSON."""
+  data = [{'subject': subject, 'body': body}
+          for (subject, body, _) in markdowns]
+  print(json.dumps(data, indent=4))
+
+
+def compose_output_gmail_sender(creds):
+  """Returns a function (messages)->Null to send each message via Gmail."""
+  sender = GmailSender(api.gmail(creds))
+
+  def _output_gmail_sender(messages):
+    nonlocal sender
+    send_messages(messages, sender)
+
+  return _output_gmail_sender
+
+
+def output_stdout_email(messages):
+  """Prints rendered emails for each recipient to the console in JSON."""
+  data = [str(message.email_message) for message in messages]
+  print(json.dumps(data, indent=4))
+
+
+def load_config(config_dir):
+  """Opens the config file, doesn't check for creds."""
+  config_path = config_module.find_config_file(config_dir)
+  config = config_module.load_from_file(config_path)
+  return config
+
+
+def needs_valid_creds(options: Options) -> bool:
+  return not (options.stdin and options.skip_send)
+
+
+def validate_creds(options: Options, config: Config):
+  """
+  Creates new creds or uses serialized creds.
+  :return: (config, creds)
+  """
+  if not needs_valid_creds(options):
+    return config, None  # not using creds, no need to refresh token
+  config_path = config_module.find_config_file(options.config_dir)
+  config.validate()
   # Accessing creds either creates new creds or uses serialized creds.
-  creds = config_obj.creds
-  config_obj = config_obj.set_serialized_creds(auth.serialize(creds))
-  config_obj.save_to_file(config_path)
-  return config_obj
+  creds = config.creds
+  config = config.set_serialized_creds(auth.serialize(creds))
+  config.save_to_file(config_path)
+  return config, creds
 
 
-def process_sheets(group, config_dir, key_names, all_keys, date, skip): # pylint: disable=too-many-arguments
-  config_obj = get_config(config_dir)
-  if all_keys:
-    sheet_ids = config_obj.get_all_keys()
-  else:
-    sheet_ids = config_obj.get_keys(key_names)
-  for sheet_id in sheet_ids:
-    data = fetcher.values(sheet_id, api.sheets(config_obj.creds))
-    extra_recipients = config_obj.get_extra_recipients_for_group(group)
-    extra_values = config_obj.get_extra_values()
-    messages = get_messages(data, date, group, extra_recipients, extra_values)
-    sender = GmailSender(api.gmail(config_obj.creds))
-    send_messages(messages, sender, skip)
+def google_sheet_ids(options: Options, config: Config):
+  """Returns a set of google sheet ids from config and options"""
+  if options.all_keys:
+    return config.get_all_keys()
+  return config.get_keys(options.key_names)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -36,6 +36,9 @@ def test_args_defaults():
   assert not options.test
   assert not options.all_keys
   assert not options.skip_send
+  assert not options.save_sheet_to
+  assert not options.stdout_markdown
+  assert not options.stdout_email
 
 
 def test_key_names_collects_values():
@@ -64,6 +67,15 @@ def test_each_group_can_be_set():
   assert args.get_parsed_args(['--active']).active
   assert args.get_parsed_args(['--dryrun']).dryrun
   assert args.get_parsed_args(['--test']).test
+
+
+def test_stdin():
+  assert args.get_parsed_args(['--stdin']).stdin
+
+
+def test_save_sheet_to_gets_value():
+  subject = args.get_parsed_args(['--save-sheet-to', 'b.json']).save_sheet_to
+  assert subject == 'b.json'
 
 
 def test_only_one_group_can_be_set():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,6 @@
 import pytest
-from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 from emailer import auth
 from emailer.auth import create_or_deserialize_creds
@@ -8,19 +8,18 @@ from emailer.auth import create_or_deserialize_creds
 
 @pytest.fixture
 def creds_dict():
-  return {
-      'token': '1',
-      'refresh_token': '2',
-      'token_uri': '3',
-      'client_id': '4',
-      'client_secret': '5',
-      'scopes': '6',
-  }
+  return {'token': '1',
+          'refresh_token': '2',
+          'token_uri': '3',
+          'client_id': '4',
+          'client_secret': '5',
+          'scopes': '6', }
 
 
 def test_fetch_new_creds_calls_right_api(monkeypatch, stub):
   def myfrom(config, scopes):
     return stub(run_console=lambda: (config, scopes))
+
   monkeypatch.setattr(InstalledAppFlow, 'from_client_config', myfrom)
   creds = auth.fetch_new_creds({'hi': 'bye'})
   config, scopes = creds  # pylint: disable=unpacking-non-sequence
@@ -29,6 +28,7 @@ def test_fetch_new_creds_calls_right_api(monkeypatch, stub):
   assert 'https://www.googleapis.com/auth/spreadsheets.readonly' in scopes
 
 
+# pylint: disable=redefined-outer-name
 def test_serialize_creds_returns_dict(stub, creds_dict):
   creds = stub(**creds_dict)
   assert auth.serialize(creds) == creds_dict
@@ -40,6 +40,7 @@ def test_creds_fetches_new_creds_when_passed_none_or_empty_dict(monkeypatch):
   assert create_or_deserialize_creds({}, 'config') == 'newconfig'
 
 
+# pylint: disable=redefined-outer-name
 def test_creds_returns_deserialized_creds_when_passed_dict(creds_dict):
   creds = create_or_deserialize_creds(creds_dict)
   assert isinstance(creds, Credentials)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,8 +25,8 @@ def test_load_nonexistent_file_raises_invalid_file_error(tmpdir):
 
 def test_load_returns_filled_config_object(tmpdir):
   config_file = tmpdir.join('config.json')
-  config_file.write(
-      json.dumps({'client_secret': 's', 'serialized_creds': 'world'}))
+  config_file.write(json.dumps({'client_secret': 's',
+                                'serialized_creds': 'world'}))
   config_data = config.load_from_file(config_file.strpath)
   assert config_data.serialized_creds == 'world'
   assert config_data.client_secret == 's'
@@ -37,6 +37,15 @@ def test_load_empty_file_raises_invalid_file_content_error(tmpdir):
     config_file = tmpdir.join('config.json')
     config_file.write('')
     config.load_from_file(config_file.strpath)
+
+
+def test_creds_calls_create_or_deserialize_creds(monkeypatch):
+  monkeypatch.setattr(config,
+                      'create_or_deserialize_creds',
+                      lambda cred, sec: (cred, sec))
+  assert Config(client_secret={'secret': 'secret'},
+                serialized_creds={'cred': 'cred'}
+                ).creds == ({'cred': 'cred'}, {'secret': 'secret'})
 
 
 def test_validate_fails_without_valid_client_secret_config():
@@ -82,16 +91,16 @@ def test_save_updates_config_file_with_data(tmpdir):
 
 
 def test_files_yields_all_possible_names():
-  assert list(config.files('/test/one')) == [
-      '/test/one/.emailer.json',
-      '/test/.emailer.json',
-      '/.emailer.json',
-      os.path.expanduser('~/.emailer.json'),
-      '/test/one/emailer.json',
-      '/test/emailer.json',
-      '/emailer.json',
-      os.path.expanduser('~/emailer.json'),
-      ]
+  subject = list(config.files('/test/one'))
+  assert subject == ['/test/one/.emailer.json',
+                     '/test/.emailer.json',
+                     '/.emailer.json',
+                     os.path.expanduser('~/.emailer.json'),
+                     '/test/one/emailer.json',
+                     '/test/emailer.json',
+                     '/emailer.json',
+                     os.path.expanduser('~/emailer.json'),
+                     ]
 
 
 def test_find_returns_first_existing_config_dot(tmpdir):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -15,6 +15,7 @@ def sheets(stub):
                   execute=lambda: data[range]))))
 
 
+# pylint: disable=redefined-outer-name
 def test_fetch_correct_sheets_and_data(sheets):
   metadata = {'sheets': [{'properties': {'title': 'Sheet1'}},
                          {'properties': {'title': 'Sheet2'}}]}

--- a/tests/test_gmailsender.py
+++ b/tests/test_gmailsender.py
@@ -11,21 +11,19 @@ def gmail(stub):
   return stub(
       users=lambda: stub(
           messages=lambda: stub(
-              send=lambda **kwargs: stub(
-                  execute=lambda: kwargs))))
+              send=lambda **kwargs: stub(execute=lambda: kwargs))))
 
 
+# pylint: disable=redefined-outer-name
 def test_send_converts_message_before_sending(gmail):
   sender = GmailSender(gmail)
   assert 'raw' in sender.send(b'hi')['body']
 
 
+# pylint: disable=redefined-outer-name
 def test_send_gmail_message_uses_me_as_user_id(gmail):
   sender = GmailSender(gmail)
-  assert sender.send_gmail_message('hi') == {
-      'userId': 'me',
-      'body': 'hi',
-      }
+  assert sender.send_gmail_message('hi') == {'userId': 'me', 'body': 'hi'}
 
 
 def test_convert_converts_messages_to_gmail_body():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import sys
 from collections import Counter
 
 import pytest
@@ -19,19 +20,14 @@ def main_spies(monkeypatch):
     counter.update(('get_sample_config', 1))
     return 'testing get sample config'
 
-  # pylint: disable=too-many-arguments, unused-argument
-  def spy_process_sheets(group,
-                         config_dir,
-                         key_names,
-                         all_keys,
-                         date,
-                         skip):
+  # pylint: disable=unused-argument
+  def spy_process(options):
     nonlocal counter
-    counter.update(('process_sheets', 1))
+    counter.update(('process', 1))
 
   monkeypatch.setattr(main, 'get_version', spy_get_version)
   monkeypatch.setattr(main, 'get_sample_config', spy_get_sample_config)
-  monkeypatch.setattr(shell, 'process_sheets', spy_process_sheets)
+  monkeypatch.setattr(shell, 'process', spy_process)
   return counter
 
 
@@ -42,7 +38,7 @@ def test_main_version(main_spies, monkeypatch):
   main.main()
   assert (main_spies['get_version']) == 1
   assert (main_spies['get_sample_config']) == 0
-  assert (main_spies['process_sheets']) == 0
+  assert (main_spies['process']) == 0
 
 
 # pylint: disable=redefined-outer-name
@@ -52,7 +48,7 @@ def test_main_sample_config(main_spies, monkeypatch):
   main.main()
   assert (main_spies['get_version']) == 0
   assert (main_spies['get_sample_config']) == 1
-  assert (main_spies['process_sheets']) == 0
+  assert (main_spies['process']) == 0
 
 
 # pylint: disable=redefined-outer-name
@@ -62,7 +58,7 @@ def test_main(main_spies, monkeypatch, capsys):
   main.main()
   assert (main_spies['get_version']) == 0
   assert (main_spies['get_sample_config']) == 0
-  assert (main_spies['process_sheets']) == 0
+  assert (main_spies['process']) == 0
   out, err = capsys.readouterr()
   assert out == 'No group provided\n'
   assert err == ''
@@ -75,4 +71,15 @@ def test_main_no_group(main_spies, monkeypatch):
   main.main()
   assert (main_spies['get_version']) == 0
   assert (main_spies['get_sample_config']) == 0
-  assert (main_spies['process_sheets']) == 1
+  assert (main_spies['process']) == 1
+
+
+def test_name_main(monkeypatch, capsys):
+  args = args_mod.get_parsed_args(['--skip-send'])
+  monkeypatch.setattr(main, 'get_parsed_args', lambda: args)
+  monkeypatch.setattr(main, '__name__', '__main__')
+  monkeypatch.setattr(sys, 'exit', lambda _code: None)
+  main.init()
+  out, err = capsys.readouterr()
+  assert out == 'No group provided\n'
+  assert err == ''

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -1,10 +1,19 @@
-from emailer.send import send_message
+from emailer import send
 
 
 def test_send_sends_message(stub):
   sender = stub(send=lambda msg: 'b')
-  assert send_message(message='a', sender=sender) == 'b'
+  assert send.send_message(message='a', sender=sender) == 'b'
 
 
-def test_skips_sending_when_skip_is_true():
-  assert send_message(message='a', sender=None, skip=True) is None
+def test_send_multiple_message(stub):
+  counter = 0
+
+  def mock_sender(_):
+    nonlocal counter
+    counter += 1
+  sender = stub(send=mock_sender)
+
+  messages = ['a', 'b', 'c']
+  send.send_messages(messages, sender=sender, sleep=0.001)
+  assert counter == 3

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -24,7 +24,7 @@ def test_process(monkeypatch):
                         markdown_outputs,
                         message_outputs,
                         sheet):
-    nonlocal mock_sheet, output_sheet_called
+    nonlocal output_sheet_called
     output_sheet_called = True
     assert options.group == 'test'
     assert config is not None
@@ -63,7 +63,6 @@ def test_decide_input_from_google(monkeypatch):
 
   def mock_input_google_sheets(options, config, creds):
     """internal function that generates a google sheets fetcher"""
-    nonlocal mock_sheets_fetcher
     assert not options.stdin
     assert config is not None
     assert creds == 'uh... sure'

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,329 @@
+import json
+import sys
+
+import pytest
+
+from emailer import args, shell, fetcher, api, auth, config as config_module
+from emailer.config import Config
+from emailer.name import EMAILS, RECIPIENTS
+from emailer.options import Options
+
+
+def test_process(monkeypatch):
+  mock_sheet = {'mock_sheet': {}}
+  output_sheet_called = False
+
+  def mock_input_source(options, config, creds):
+    assert options.group == 'test'
+    assert config is not None
+    assert creds is None
+    return lambda: [mock_sheet]
+
+  def mock_output_sheet(options,
+                        config,
+                        markdown_outputs,
+                        message_outputs,
+                        sheet):
+    nonlocal mock_sheet, output_sheet_called
+    output_sheet_called = True
+    assert options.group == 'test'
+    assert config is not None
+    assert markdown_outputs is not None
+    assert message_outputs is not None
+    assert sheet == mock_sheet
+
+  monkeypatch.setattr(shell, "decide_input_source", mock_input_source)
+  monkeypatch.setattr(shell, "output_sheet", mock_output_sheet)
+  monkeypatch.setattr(shell, "needs_valid_creds", lambda _: False)
+  monkeypatch.setattr(shell, "load_config", lambda _: Config())
+  monkeypatch.setattr(shell, "compose_output_gmail_sender",
+                      lambda _: lambda _: None)
+
+  opts = Options(args.get_parsed_args(['--test']))
+  shell.process(opts)
+  assert output_sheet_called
+
+
+def test_decide_input_from_stdin():
+  """Given the --stdin argument, Then the input source should be stdin."""
+  options = Options(args.get_parsed_args(['--stdin']))
+  config = Config()
+  creds = None
+  # pylint: disable=comparison-with-callable
+  assert shell.decide_input_source(options,
+                                   config,
+                                   creds) == shell.input_sheet_from_stdin
+
+
+def test_decide_input_from_google(monkeypatch):
+  """Given --stdin is not set, Then the input source should be Google Sheets."""
+
+  def mock_sheets_fetcher():
+    """fake Google Sheets fetcher"""
+
+  def mock_input_google_sheets(options, config, creds):
+    """internal function that generates a google sheets fetcher"""
+    nonlocal mock_sheets_fetcher
+    assert not options.stdin
+    assert config is not None
+    assert creds == 'uh... sure'
+    return mock_sheets_fetcher
+
+  monkeypatch.setattr(shell,
+                      "compose_input_google_sheets",
+                      mock_input_google_sheets)
+
+  opts = Options(args.get_parsed_args([]))
+  cfg = Config()
+  # pylint: disable=comparison-with-callable
+  assert shell.decide_input_source(opts,
+                                   cfg,
+                                   'uh... sure') == mock_sheets_fetcher
+  mock_sheets_fetcher()  # 100% coverage
+
+
+def test_google_sheets_fetcher_called_with_ids(monkeypatch):
+  monkeypatch.setattr(fetcher, "values",
+                      lambda sheet_id, _: 'fetched_' + sheet_id)
+  monkeypatch.setattr(api, "sheets", lambda creds: None)
+
+  config = Config(keys={'a': '1', 'b': '2'})
+  options = Options(args.get_parsed_args(['--all-keys']))
+  sheets_fetcher = shell.compose_input_google_sheets(options=options,
+                                                     config=config,
+                                                     creds='sup')
+  sheets = sheets_fetcher()
+
+  assert set(sheets) == {'fetched_1', 'fetched_2'}
+
+
+def test_sheet_from_stdin(monkeypatch):
+  monkeypatch.setattr(sys.stdin, "read", lambda: '{"json":"data"}')
+  subject = shell.input_sheet_from_stdin()
+  assert list(subject) == [{"json": "data"}]
+
+
+def test_decide_markdown_outputs():
+  options = Options(args.get_parsed_args(['--stdout-markdown']))
+  subject = shell.decide_markdown_outputs(options)
+  assert subject == [shell.output_stdout_markdown]
+
+
+def test_decide_message_outputs(monkeypatch):
+  def mock_compose_output_gmail_sender(creds):
+    assert creds == 'sup'
+    return 'test gmail sender'
+
+  monkeypatch.setattr(shell, "compose_output_gmail_sender",
+                      mock_compose_output_gmail_sender)
+
+  options = Options(args.get_parsed_args(['--stdout-email', '--skip-send']))
+  outputs = shell.decide_message_outputs(options=options, creds='sup')
+  assert len(outputs) == 1, "should have a stdout sender"
+  # pylint: disable=comparison-with-callable
+  assert outputs[0] == shell.output_stdout_email
+
+  options = Options(args.get_parsed_args(['--stdout-email']))
+  outputs = shell.decide_message_outputs(options=options, creds='sup')
+  assert len(outputs) == 2, "should have both stdout and gmail senders"
+  # pylint: disable=comparison-with-callable
+  assert outputs[0] == shell.output_stdout_email
+  assert outputs[1] == 'test gmail sender'
+
+  options = Options(args.get_parsed_args([]))
+  outputs = shell.decide_message_outputs(options=options, creds='sup')
+  assert len(outputs) == 1, "should have a gmail sender"
+  assert outputs[0] == 'test gmail sender'
+
+  options = Options(args.get_parsed_args(['--skip-send']))
+  outputs = shell.decide_message_outputs(options=options, creds='sup')
+  assert len(outputs) == 0, "should have zero senders"
+
+
+class OutputMock:
+  def __init__(self):
+    self.sheet = {EMAILS: [["email_date", "", "2019-10-17"],
+                           ["email_subject", "", "test subject"],
+                           ["email_body", "", "test body\n$test_var"],
+                           ["test_var", "", "hi"], ],
+                  RECIPIENTS: [["Email", "Active", "Dryrun", "Test"],
+                               ["test@example.com", "", "", "x"], ]}
+    self.markdown_called, self.message_called = False, False
+
+  def stub_markdown_output(self, markdowns):
+    self.markdown_called = True
+    assert len(markdowns) == 1, "at least one message should be markdown"
+    subject, body, _ = markdowns[0]
+    assert subject == '[TEST] test subject'
+    assert body == 'test body\nhi'
+
+  def stub_message_output(self, messages):
+    self.message_called = True
+    assert len(messages) == 1, "at least one message should be sent to output"
+    message = messages[0]
+    assert message.subject == '[TEST] test subject'
+    assert message.recipient.email == 'test@example.com'
+
+
+@pytest.fixture
+def output_fixture():  # pylint: disable=redefined-outer-name
+  return OutputMock()
+
+
+# pylint: disable=redefined-outer-name
+def test_output(output_fixture):
+  config = Config(keys={'a': 1, 'b': 2})
+  options = Options(args.get_parsed_args(['-d', '2019-10-17',
+                                          '--all-keys',
+                                          '--test']))
+  markdown_outputs = [output_fixture.stub_markdown_output]
+  message_outputs = [output_fixture.stub_message_output]
+  shell.output_sheet(options, config, markdown_outputs, message_outputs,
+                     output_fixture.sheet)
+  assert output_fixture.markdown_called
+  assert output_fixture.message_called
+
+
+# pylint: disable=redefined-outer-name
+def test_output_no_message_handlers(output_fixture):
+  config = Config(keys={'a': 1, 'b': 2})
+  options = Options(args.get_parsed_args(['-d',
+                                          '2019-10-17',
+                                          '--all-keys',
+                                          '--test']))
+  markdown_outputs = [output_fixture.stub_markdown_output]
+  message_outputs = []
+  shell.output_sheet(options, config, markdown_outputs, message_outputs,
+                     output_fixture.sheet)
+  assert output_fixture.markdown_called
+  assert not output_fixture.message_called
+
+
+def test_save_sheet(tmpdir):
+  out_json = tmpdir.join('out.json')
+  out_json.write('')
+  shell.save_sheet(out_json.strpath, [{'test': 'data'}])
+  assert out_json.read() == '[\n    {\n        "test": "data"\n    }\n]'
+
+
+def test_get_emails_parses_and_composes():
+  sheet = {EMAILS: [["email_date", "", "2019-10-17"],
+                    ["email_subject", "", "test subject"],
+                    ["email_body", "", "test body\n$test_var"],
+                    ["test_var", "", "hi"]]}
+  markdowns = shell.markdown_emails_for_date(sheet=sheet,
+                                             send_date='2019-10-17',
+                                             group='test', extra_values={})
+  markdowns = list(markdowns)
+  assert len(markdowns) == 1, "one markdown should be generated"
+  subject, body, values = markdowns[0]
+  assert subject == '[TEST] test subject'
+  assert body == 'test body\nhi'
+  assert values.get('email_date') == '2019-10-17'
+
+
+def test_stdout_markdown(capsys):
+  emails = [('test subject', 'test body', {})]
+
+  shell.output_stdout_markdown(emails)
+
+  out, _err = capsys.readouterr()
+  j = json.loads(out)
+  assert j == [{'body': 'test body', 'subject': 'test subject'}]
+
+
+def test_stdout_email(capsys, stub):
+  messages = [stub(email_message='a'), stub(email_message='b')]
+
+  shell.output_stdout_email(messages)
+
+  out, _err = capsys.readouterr()
+  j = json.loads(out)
+  assert j == ['a', 'b']
+
+
+def test_output_gmail(monkeypatch):
+  messages = []
+  monkeypatch.setattr(api, "gmail", lambda creds: None)
+  monkeypatch.setattr(shell, 'GmailSender', lambda _: None)
+  monkeypatch.setattr(shell, 'send_messages',
+                      lambda ms, s: [messages.append(m) for m in ms])
+  sender = shell.compose_output_gmail_sender('sup')
+  sender(['a', 'b', 'c'])
+  assert messages == ['a', 'b', 'c']
+
+
+def test_get_messages():
+  sheet = {EMAILS: [["email_date", "", "2019-10-17"],
+                    ["email_subject", "", "test subject"],
+                    ["email_body", "", "test body\n$test_var"],
+                    ["test_var", "", "hi"]],
+           RECIPIENTS: [["Email", "Active", "Dryrun", "Test"],
+                        ["test@example.com", "", "x", "x"], ]}
+  emails = [('subject', 'body', {})]
+  group = 'test'
+  cfg = Config(extra_emails={"test": ["Extra Tester <extra@example.com>"]})
+  extra_recipients = cfg.get_extra_recipients_for_group('test')
+
+  result = shell.messages_from_markdown(sheet, emails, group, extra_recipients)
+
+  result = list(result)
+  assert len(result) == 2
+  msg1, msg2 = result
+
+  assert msg1.subject == 'subject'
+  assert 'body' in msg1.html_body
+  assert msg1.recipient.email == 'test@example.com'
+
+  assert msg2.subject == 'subject'
+  assert 'body' in msg2.html_body
+  assert msg2.recipient.email == 'Extra Tester <extra@example.com>'
+
+
+def test_validate_creds(monkeypatch):
+  options = Options(args.get_parsed_args(['--all-keys']))
+  config = Config()
+  monkeypatch.setattr(config_module, 'find_config_file', lambda _: None)
+  monkeypatch.setattr(Config, 'validate', lambda _: None)
+  monkeypatch.setattr(Config, 'creds', 'sup')
+  monkeypatch.setattr(auth, 'serialize', lambda _: 'sup')
+  monkeypatch.setattr(Config, 'set_serialized_creds', lambda _self, _: _self)
+  monkeypatch.setattr(Config, 'save_to_file', lambda _self, _: None)
+  new_config, creds = shell.validate_creds(options, config)
+  assert new_config is config
+  assert creds == 'sup'
+
+
+def test_validate_creds_heuristic_for_when_not_used(monkeypatch):
+  options = Options(args.get_parsed_args(['--stdin', '--skip-send']))
+  config = Config()
+  monkeypatch.setattr(shell, 'needs_valid_creds', lambda _: False)
+  new_config, creds = shell.validate_creds(options, config)
+  assert new_config is config
+  assert creds is None
+
+
+def test_load_config(monkeypatch):
+  config = Config()
+  monkeypatch.setattr(config_module, 'find_config_file', lambda _: None)
+  monkeypatch.setattr(config_module, 'load_from_file', lambda _: config)
+  assert shell.load_config('test_dir') is config
+
+
+def test_needs_valid_creds(stub):
+  assert shell.needs_valid_creds(stub(stdin=True, skip_send=True)) is False
+  assert shell.needs_valid_creds(stub(stdin=False, skip_send=True)) is True
+  assert shell.needs_valid_creds(stub(stdin=True, skip_send=False)) is True
+  assert shell.needs_valid_creds(stub(stdin=False, skip_send=False)) is True
+
+
+def test_gets_all_sheet_ids():
+  options = Options(args.get_parsed_args(['--all-keys']))
+  config = Config(keys={'a': 1, 'b': 2})
+  assert shell.google_sheet_ids(options, config) == {1, 2}
+
+
+def test_gets_selected_sheet_ids():
+  options = Options(args.get_parsed_args(['-k', 'a', 'b']))
+  config = Config(keys={'a': '1', 'b': '2', 'c': '3'})
+  assert shell.google_sheet_ids(options, config) == {'1', '2'}


### PR DESCRIPTION
I'm making other tools to help me fill out the schedule, or view it on the monitor at the sound booth.
There are some issues I keep running against:
* I'd like to run the emailer in a stateless environment, but it needs an `emailer.json`
* Google Sheets doesn't let me make newlines on any phone or tablet.  If I touch a field without editing it, it adds quotes.  Only desktop browsers work.
* I'd like to get the Markdown output in an automated way, without scraping `-v`

I spent a bit of time thinking about how to make emailer more like a UNIX program, that takes in text, and outputs text.  And I wanted to do it in a "clean" way, where inputs and outputs can be added dynamically.  But who knows if it's easy to read, there's a lot of monkeypatch and not a lot of DI in the tests.  But shell is now 100% covered.  So comments and critique are welcome.

# New Features
* `--stdin` takes a JSON file representing a sheet from the stdin instead of using Google Sheets API.
* `--save-sheet-to` saves the input from Google Sheets to a JSON file (that could be later used for `--stdin`, but this is really just for debugging IMO.
* `--stdout-markdown` Prints the composed base emails into a JSON output.
* `--stdout-email` Prints each individual highlighted email into a JSON output.

## Example
This outputs the markdown body of the email sent on 10/17, without accessing Google Sheets or Gmail apis, and without refreshing the token.
```bash
cat ../data.json | python -m emailer -k seattle --active -d 2019-10-17 --stdin --skip-send --stdout-markdown | jq '.[0].body'
```


I also updated test coverage to 94%.  Which is 100% in every file except `__init__.py` `__main__.py` and `main.py` because of time.

Includes #29 and #30