### PR TITLE
Using multi-part email

### DIFF
--- a/emailer/messagebuilder.py
+++ b/emailer/messagebuilder.py
@@ -12,4 +12,5 @@ def create_message_for_recipient(recipient, subject, body, values):
                  sender=sender,
                  recipient=recipient,
                  replyto=replyto,
-                 html_body=html_body)
+                 html_body=html_body,
+                 plain_body=body)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -28,6 +28,7 @@ def test_message_body_is_email_message_content():
   html = '<h1>Hi</h1>\n'
   message = Message(html_body=html, plain_body=plain)
   payloads = [m.get_payload() for m in message.email_message.get_payload()]
+  # `plain` is not base64 encoded, because 'Hi\n' doesn't include unicode characters.
   expected = [plain, b64encode(html.encode('utf-8')).decode('utf-8') + '\n']
   assert payloads == expected
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -28,7 +28,7 @@ def test_message_body_is_email_message_content():
   html = '<h1>Hi</h1>\n'
   message = Message(html_body=html, plain_body=plain)
   payloads = [m.get_payload() for m in message.email_message.get_payload()]
-  # `plain` is not base64 encoded, because 'Hi\n' doesn't include unicode characters.
+  # `plain` is not base64 encoded, because 'Hi\n' doesn't include unicode
   expected = [plain, b64encode(html.encode('utf-8')).decode('utf-8') + '\n']
   assert payloads == expected
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,11 +1,11 @@
-from email.message import EmailMessage
-
+from base64 import b64encode
+from email.mime.multipart import MIMEMultipart
 from emailer.message import Message
 from emailer.recipient import Recipient
 
 
 def test_message_has_email_message():
-  assert isinstance(Message().email_message, EmailMessage)
+  assert isinstance(Message().email_message, MIMEMultipart)
 
 
 def test_message_fields_are_in_email_message():
@@ -16,20 +16,20 @@ def test_message_fields_are_in_email_message():
                     sender=sender,
                     recipient=recipient,
                     replyto=replyto)
-  assert message.email_message.items() == [
-      ('Subject', 'Hi'),
-      ('From', sender.email),
-      ('To', recipient.email),
-      ('Reply-To', replyto.email),
-      ('Content-Type', 'text/html; charset="utf-8"'),
-      ('Content-Transfer-Encoding', 'quoted-printable'),
-      ('MIME-Version', '1.0'),
-  ]
+  items = message.email_message.items()
+  assert ('Subject', 'Hi') in items
+  assert ('From', sender.email) in items
+  assert ('To', recipient.email) in items
+  assert ('Reply-To', replyto.email) in items
 
 
 def test_message_body_is_email_message_content():
-  message = Message(html_body='<h1>Hi</h1>\n')
-  assert message.email_message.get_content() == '<h1>Hi</h1>\n'
+  plain = 'Hi\n'
+  html = '<h1>Hi</h1>\n'
+  message = Message(html_body=html, plain_body=plain)
+  payloads = [m.get_payload() for m in message.email_message.get_payload()]
+  expected = [plain, b64encode(html.encode('utf-8')).decode('utf-8') + '\n']
+  assert payloads == expected
 
 
 def test_message_bytes_pass_through_to_email_message_as_bytes():


### PR DESCRIPTION
To support clients that can't read html, or only use plain for low bandwidth, privacy or battery saving mode.

## Why?
I logged into the account I was using to send messages, and someone from a Gmail account couldn't read the html version :(
Also I noticed email at a client's site, they sent a bad plain-text version.  Because on my iPhone's default Mail app when I was on LTE it showed the plain version, but on WiFi the email was formatted with HTML correctly.

So modern email clients will display plaintext.

## Details
This PR adds a plain and html version.

Unfortunately MIMEText always encodes as base64 even if Content-Transfer-Encoding is changed for if the text has unicode chars in it.  So if the text is non-ascii then the plain part will be base64 encoded.  However in practice the plain part is still shown to the user decoded, it's just if you are inspecting the original message that you can't read it.
YMMV