### PR TITLE
Use setup.cfg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-source=
-  emailer
-  tests
-
-[report]
-show_missing=true
-skip_covered=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/prod
 /.coverage
 /.pytest_cache
 /.tox

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-addopts = -ra -vv
-testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,7 @@ envlist = py37
 [testenv]
 deps = pytest
 commands = pytest {posargs}
+
+[tool:pytest]
+addopts = -ra -vv
+testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,12 @@ commands = pytest {posargs}
 [tool:pytest]
 addopts = -ra -vv
 testpaths = tests
+
+[coverage:run]
+source=
+  emailer
+  tests
+
+[coverage:report]
+show_missing=true
+skip_covered=true

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,10 @@ column_limit = 80
 blank_line_before_nested_class_or_def = true
 blank_line_before_module_docstring = true
 indent_width = 2
+
+[tox:tox]
+envlist = py37
+
+[testenv]
+deps = pytest
+commands = pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py37
-
-[testenv]
-deps = pytest
-commands = pytest {posargs}


### PR DESCRIPTION
Consolidate configuration in setup.cfg. Sadly pylint only supports setup.cfg from version 2.5+, and they have not yet released any version past 2.4+. Will consolidate pylint settings later.

Considered using pyproject.toml but its PEP is still only provisional: https://www.python.org/dev/peps/pep-0518/